### PR TITLE
Add support for editing encrypted .tsc files

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,24 @@
 				"path": "./syntaxes/tsc.tmLanguage.json"
 			}
 		],
+		"configuration": [
+			{
+				"title": "Cave Story TSC Configuration",
+				"properties": {
+					"tsc.trace.server": {
+						"scope": "window",
+						"type": "string",
+						"enum": [
+							"off",
+							"messages",
+							"verbose"
+						],
+						"default": "off",
+						"description": "Traces the communication between VS Code and the TSC language server."
+					}
+				}
+			}
+		],
 		"commands": [
 			{
 				"command": "vscode-tsc.restartLsp",

--- a/src/EncodedTSCFileSystemProvider.ts
+++ b/src/EncodedTSCFileSystemProvider.ts
@@ -50,6 +50,10 @@ export class EncodedTSCFileSystemProvider implements vscode.FileSystemProvider {
 		const key = buf[half] === 0 ? 0xf9 : -buf[half] & 0xff;
 
 		for (let i = 0; i < buf.length; i++) {
+			if (i === half) {
+				continue;
+			}
+
 			buf[i] = (buf[i] + key) & 0xff;
 		}
 
@@ -66,6 +70,10 @@ export class EncodedTSCFileSystemProvider implements vscode.FileSystemProvider {
 		const key = buf[half] === 0 ? 0xf9 : -buf[half] & 0xff;
 
 		for (let i = 0; i < buf.length; i++) {
+			if (i === half) {
+				continue;
+			}
+
 			buf[i] = (buf[i] - key) & 0xff;
 		}
 

--- a/src/EncodedTSCFileSystemProvider.ts
+++ b/src/EncodedTSCFileSystemProvider.ts
@@ -1,0 +1,86 @@
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+
+export class EncodedTSCFileSystemProvider implements vscode.FileSystemProvider {
+	onDidChangeFile: vscode.Event<
+		vscode.FileChangeEvent[]
+	> = new vscode.EventEmitter<vscode.FileChangeEvent[]>().event;
+
+	watch(
+		uri: vscode.Uri,
+		options: { recursive: boolean; excludes: string[] }
+	): vscode.Disposable {
+		return new vscode.Disposable(() => {});
+	}
+
+	async stat(uri: vscode.Uri): Promise<vscode.FileStat> {
+		try {
+			const stat = await fs.promises.stat(uri.fsPath);
+			const type = stat.isSymbolicLink()
+				? vscode.FileType.SymbolicLink
+				: stat.isDirectory()
+				? vscode.FileType.Directory
+				: stat.isFile()
+				? vscode.FileType.File
+				: vscode.FileType.Unknown;
+
+			return {
+				type,
+				size: stat.size,
+				ctime: stat.ctimeMs,
+				mtime: stat.mtimeMs,
+			};
+		} catch (e) {
+			throw vscode.FileSystemError.FileNotFound(uri);
+		}
+	}
+
+	readDirectory(
+		uri: vscode.Uri
+	): [string, vscode.FileType][] | Thenable<[string, vscode.FileType][]> {
+		return [];
+	}
+
+	createDirectory(uri: vscode.Uri): void | Thenable<void> {}
+
+	async readFile(uri: vscode.Uri): Promise<Uint8Array> {
+		const buf = await fs.promises.readFile(uri.fsPath);
+
+		const half = (buf.length / 2) | 0;
+		const key = buf[half] === 0 ? 0xf9 : -buf[half] & 0xff;
+
+		for (let i = 0; i < buf.length; i++) {
+			buf[i] = (buf[i] + key) & 0xff;
+		}
+
+		console.log('Loaded encoded TSC', uri.fsPath, 'with key:', key);
+		return buf;
+	}
+
+	async writeFile(
+		uri: vscode.Uri,
+		buf: Uint8Array,
+		options: { create: boolean; overwrite: boolean }
+	): Promise<void> {
+		const half = (buf.length / 2) | 0;
+		const key = buf[half] === 0 ? 0xf9 : -buf[half] & 0xff;
+
+		for (let i = 0; i < buf.length; i++) {
+			buf[i] = (buf[i] - key) & 0xff;
+		}
+
+		fs.writeFileSync(uri.fsPath, buf);
+		console.log('Saved encoded TSC', uri.fsPath, 'with key:', key);
+	}
+
+	delete(
+		uri: vscode.Uri,
+		options: { recursive: boolean }
+	): void | Thenable<void> {}
+
+	rename(
+		oldUri: vscode.Uri,
+		newUri: vscode.Uri,
+		options: { overwrite: boolean }
+	): void | Thenable<void> {}
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -66,6 +66,10 @@ export async function activate(ctx: ExtensionContext) {
 				language: 'tsc'
 			},
 			{
+				scheme: 'encoded-tsc',
+				language: 'tsc'
+			},
+			{
 				scheme: 'untitled',
 				language: 'tsc'
 			}


### PR DESCRIPTION
My patch adds support for seamless encryption/decryption of the .tsc file via simple virtual filesystem hook.

When an encrypted .tsc file is opened, a notification asking the user whether the file should be opened in text mode appears, and once the `Reopen in text mode` option is selected, the extension opens a new editor window which seamlessly handles the encryption.

I don't know whether TSC language server works, I haven't checked since no builds for Linux were provided.

![](https://media.discordapp.net/attachments/489123163330838529/786012445935140895/unknown.png)
![](https://media.discordapp.net/attachments/489123163330838529/786012485227380776/unknown.png)